### PR TITLE
Patches issue with default effects

### DIFF
--- a/CustomAmmoCategories/OnAttackSequenceResolveDamage.cs
+++ b/CustomAmmoCategories/OnAttackSequenceResolveDamage.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Harmony;
 using BattleTech;
 using BattleTech.AttackDirectorHelpers;
@@ -56,7 +55,7 @@ namespace CustomAmmoCategoriesPatches
                     }
                     if (attackIndex > -1)
                     {
-                        //typeof(AttackDirector.AttackSequence).GetProperty("attackCompletelyMissed", BindingFlags.NonPublic).SetValue(__instance, (object)false);
+                        //typeof(AttackDirector.AttackSequence).GetProperty("attackCompletelyMissed", BindingFlags.NonPublic).SetValue(__instance, (object)false);  
                         PropertyInfo property = typeof(AttackDirector.AttackSequence).GetProperty("attackCompletelyMissed");
                         property.DeclaringType.GetProperty("attackCompletelyMissed");
                         property.GetSetMethod(true).Invoke(__instance, new object[1] { (object)false });
@@ -64,14 +63,18 @@ namespace CustomAmmoCategoriesPatches
                     }
                     if (attackIndex > -1 && !__instance.target.IsDead && target != null)
                     {
-                        foreach (EffectData statusEffect in CustomAmmoCategories.getWeaponStatusEffects(weapon))
-                        {
-                            if (statusEffect.targetingData.effectTriggerType == EffectTriggerType.OnHit)
-                            {
+                        foreach (EffectData statusEffect in CustomAmmoCategories.getWeaponStatusEffects(weapon)) {
+                            if (statusEffect.targetingData.effectTriggerType == EffectTriggerType.OnHit) {
                                 string effectID = string.Format("OnHitEffect_{0}_{1}", (object)__instance.attacker.GUID, (object)resolveDamageMessage.hitInfo.attackSequenceId);
-                                __instance.Director.Combat.EffectManager.CreateEffect(statusEffect, effectID, __instance.stackItemUID, (ICombatant)__instance.attacker, __instance.target, hitInfo, attackIndex, false);
-                                if (__instance.target != null)
-                                    __instance.Director.Combat.MessageCenter.PublishMessage((MessageCenterMessage)new FloatieMessage(__instance.target.GUID, __instance.target.GUID, statusEffect.Description.Name, FloatieMessage.MessageNature.Debuff));
+                                if (statusEffect.Description == null || statusEffect.Description.Id == null || statusEffect.Description.Name == null) {
+                                    CustomAmmoCategoriesLog.Log.LogWrite($"WARNING: EffectID:{effectID} has broken effectDescId:{statusEffect?.Description.Id} effectDescName:{statusEffect?.Description.Name}! SKIPPING");
+                                } else {
+                                    CustomAmmoCategoriesLog.Log.LogWrite($"Applying effectID:{effectID} with effectDescId:{statusEffect?.Description.Id} effectDescName:{statusEffect?.Description.Name}");
+
+                                    __instance.Director.Combat.EffectManager.CreateEffect(statusEffect, effectID, __instance.stackItemUID, (ICombatant)__instance.attacker, __instance.target, hitInfo, attackIndex, false);
+                                    if (__instance.target != null)
+                                        __instance.Director.Combat.MessageCenter.PublishMessage((MessageCenterMessage)new FloatieMessage(__instance.target.GUID, __instance.target.GUID, statusEffect.Description.Name, FloatieMessage.MessageNature.Debuff));
+                                }
                             }
                         }
                         if (target != null)


### PR DESCRIPTION
During testing of RT 998 alpha, several issues were found that stemmed from the following stacktrace:

```
2019-02-08T05:57:38 FYLS [ERROR] CRITICAL ERROR, PLEASE REPORT:
Delegate OnActorTakeDamage - Standard for message type OnTakeDamage failed with exception 
Argument cannot be null.
Parameter name: key
at System.Collections.Generic.Dictionary`2<string, BattleTech.UI.CombatHUDStatusIndicator>.ContainsKey (string) <0x001cc>
at BattleTech.UI.CombatHUDStatusPanel.ShowEffectStatuses (BattleTech.AbstractActor,BattleTech.AbilityDef/SpecialRules) <0x0018f>
at (wrapper dynamic-method) BattleTech.UI.CombatHUDStatusPanel.RefreshDisplayedCombatant_Patch1 (object) <0x00111>
at BattleTech.UI.CombatHUDStatusPanel.set_DisplayedCombatant (BattleTech.ICombatant) <0x0002a>
at (wrapper dynamic-method) BattleTech.UI.CombatHUDTargetingComputer.RefreshActorInfo_Patch1 (object) <0x00151>
at BattleTech.UI.CombatHUDTargetingComputer.OnActorTakeDamage (MessageCenterMessage) <0x00289>
at MessageCenter.SendMessagesForType (MessageCenterMessageType,MessageCenterMessage) <0x00186>
```

We investigated many mods and the code and found that the issue came down to this call:
```
string id = <ShowEffectStatuses>c__AnonStorey.effects[i].EffectData.Description.Id;
if (!this.effectDict.ContainsKey(id))
```
I added some logging to one of my mods and found that targets were receiving OnHit effects that had no Description.Id or Description.Name. This patch prevents those effects from being applied, since it breaks various other methods through the HBS code.

I could not pin down exactly why these weapons have issues; LadyAlekto was testing using a LRM+Hydra ammo. I'll attach the CustomAmmoCategories log, but the relevant snippet is:

```
  modified AttackRecoil
AttackDirector.AttackSequence.OnAttackSequenceResolveDamagegetWeaponStatusEffects LRM15 +(Hydra)
  weapon has no additional status effects
AttackDirector.AttackSequence.OnAttackSequenceResolveDamagegetWeaponStatusEffects LRM15 +(Hydra)
  weapon has no additional status effects
AttackDirector.AttackSequence.Cleanup
  weapon M Laser
  weapon LRM15 +
```

[CustomAmmoCategories.log](https://github.com/CMiSSioN/CustomAmmoCategories/files/2847363/CustomAmmoCategories.log)
