### PR TITLE
fix TryExpand() to roll against correct value

### DIFF
--- a/CustomAmmoCategories/DynamicMap.cs
+++ b/CustomAmmoCategories/DynamicMap.cs
@@ -561,7 +561,7 @@ namespace CustAmmoCategories {
         return false;
       };
       float roll = Random.Range(0f, 1f);
-      if (roll > CustomAmmoCategories.Settings.BurningForestStrength) {
+      if (roll > CustomAmmoCategories.Settings.BurningForestBaseExpandChance) {
         CustomAmmoCategoriesLog.Log.LogWrite("  roll fail\n");
         return false;
       };


### PR DESCRIPTION
TryExpand() should be rolling against BurningForestBaseExpandChance, not BurningForestStrength, when testing whether to set a new cell on fire or not.